### PR TITLE
feat: rename package from @neovici/cosmoz-dialog-next to @neovici/cosmoz-dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
-# cosmoz-dialog-next
-Next version of cosmoz-dialog with pionjs
+# cosmoz-dialog
+Cosmoz dialog component built with pionjs
+
+> **Note:** This package was previously published as `@neovici/cosmoz-dialog-next`.
+> Starting from v4.0.0, it replaces the old Polymer-based `@neovici/cosmoz-dialog`.

--- a/package.json
+++ b/package.json
@@ -1,20 +1,20 @@
 {
-  "name": "@neovici/cosmoz-dialog-next",
-  "version": "1.3.0",
-  "description": "Next version of cosmoz-dialog with pionjs",
+  "name": "@neovici/cosmoz-dialog",
+  "version": "4.0.0",
+  "description": "Cosmoz dialog component built with pionjs",
   "keywords": [
     "web-components",
     "dialog",
     "pion",
     "lit-html"
   ],
-  "homepage": "https://github.com/Neovici/cosmoz-dialog-next#readme",
+  "homepage": "https://github.com/Neovici/cosmoz-dialog#readme",
   "bugs": {
-    "url": "https://github.com/Neovici/cosmoz-dialog-next/issues"
+    "url": "https://github.com/Neovici/cosmoz-dialog/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Neovici/cosmoz-dialog-next"
+    "url": "https://github.com/Neovici/cosmoz-dialog"
   },
   "license": "Apache-2.0",
   "author": "",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
 		"types": ["node", "mocha"],
 		"baseUrl": ".",
 		"paths": {
-			"@neovici/cosmoz-dialog-next/*": ["./src/*"]
+			"@neovici/cosmoz-dialog/*": ["./src/*"]
 		}
 	},
 	"include": ["src/**/*", "test/**/*", "stories/**/*"]


### PR DESCRIPTION
## Summary

- Rename npm package from `@neovici/cosmoz-dialog-next` to `@neovici/cosmoz-dialog`
- Bump version to `4.0.0` (breaking change, replaces old Polymer-based v3.x)
- Update repository URLs, homepage, bugs URL
- Update tsconfig path alias
- Update README

## Context

The migration from old Polymer `cosmoz-dialog` to `cosmoz-dialog-next` is complete (NEO-1006 sub-issues). The `-next` suffix is no longer needed.

The GitHub repo has already been renamed from `Neovici/cosmoz-dialog-next` → `Neovici/cosmoz-dialog` (the old Polymer repo was renamed to `cosmoz-dialog-old` and archived).

## After merge

1. Publish `@neovici/cosmoz-dialog@4.0.0` to npm
2. Update downstream consumers (`cosmoz-form`, `cosmoz-frontend`) via separate PRs
3. Deprecate `@neovici/cosmoz-dialog-next` on npm

Ref: NEO-1130