### PR TITLE
feat: finalize v4 as the canonical cosmoz-dialog release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # cosmoz-dialog
+
 Cosmoz dialog component built with pionjs
 
-> **Note:** This package was previously published as `@neovici/cosmoz-dialog-next`.
-> Starting from v4.0.0, it replaces the old Polymer-based `@neovici/cosmoz-dialog`.
+> **Note:** This package was previously published as `@neovici/cosmoz-dialog-next`. Starting from v4.0.0, it replaces the old Polymer-based `@neovici/cosmoz-dialog` (v3.x and earlier).


### PR DESCRIPTION
## Summary

- Triggers a major version bump from v3 → v4.0.0 via semantic-release
- v4.0.0 is the canonical release that supersedes the old Polymer-based `@neovici/cosmoz-dialog` (v3.x)

## Context

PR #7 renamed the package and semantic-release published as `2.0.0` (based on git tag history from `cosmoz-dialog-next`). A `v3.0.0` tag was created at HEAD so that this `BREAKING CHANGE` commit triggers `4.0.0`.

After merge, `@neovici/cosmoz-dialog@4.0.0` will be published, and `2.0.0` can be deprecated.

Ref: NEO-1130