### PR TITLE
fix: use DOM lookup in @connected handler to avoid race condition

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -61,8 +61,8 @@ export const dialog = <T extends Props = Props>(
 						</style>`,
 				)}
 				<cosmoz-dialog-connectable
-					@connected=${() => {
-						const dlg = dialogRef.current;
+					@connected=${(e) => {
+						const dlg = e.target.querySelector('dialog');
 						if (dlg && !dlg.open) dlg.showModal();
 					}}
 				>


### PR DESCRIPTION
## Summary
Fixed race condition in dialog wrapper that prevented native <dialog> elements from opening when rendered via lit-html portals or async templates.

## Problem
The @connected event handler relied on dialogRef.current, which could be undefined when connectedCallback fires before the ref() directive assigns the dialog element.

## Solution
Changed the @connected handler to use DOM lookup via e.target.querySelector('dialog') instead of relying on the ref.

## Changes
- Modified src/index.ts: Updated @connected event handler to use event target for DOM lookup