### PR TITLE
feat: dialog body padding

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,12 +54,14 @@ export const renderDialog = ({
 					>
 						${xCloseIcon({ width: '20', height: '20' })}
 					</cosmoz-button>
-				`,
+				`
 			)}
 		</div>
 
 		<div class="divider"></div>
-		<div class="content" part="content">${content}</div>
+		<div class="content" part="content">
+			<div class="body">${content}</div>
+		</div>
 	`;
 };
 
@@ -67,7 +69,7 @@ type Opts<P extends object> = ComponentOptions<P> & { styles?: unknown };
 
 export const dialog = <T extends Props = Props>(
 	renderer: (host: HTMLElement & T) => unknown,
-	{ observedAttributes, styles: extraStyles, ...opts }: Opts<T> = {},
+	{ observedAttributes, styles: extraStyles, ...opts }: Opts<T> = {}
 ) =>
 	component<T>(
 		(host) => {
@@ -81,7 +83,7 @@ export const dialog = <T extends Props = Props>(
 					() =>
 						html`<style>
 							${extraStyles}
-						</style>`,
+						</style>`
 				)}
 				<cosmoz-dialog-connectable
 					@connected=${(e: Event) => {
@@ -114,5 +116,5 @@ export const dialog = <T extends Props = Props>(
 			] as ComponentOptions<T>['observedAttributes'],
 			styleSheets: [normalize, styles],
 			...opts,
-		},
+		}
 	);

--- a/src/loading.ts
+++ b/src/loading.ts
@@ -11,16 +11,15 @@ customElements.define(
 					flex-direction: row;
 					align-items: center;
 					justify-content: center;
-					padding: calc(var(--cz-spacing) * 8) calc(var(--cz-spacing) * 6);
+					gap: calc(var(--cz-spacing) * 3);
 				}
 				cosmoz-spinner {
 					width: 32px;
 					height: 32px;
-					margin-right: calc(var(--cz-spacing) * 3);
 				}
 			</style>
 			<cosmoz-spinner></cosmoz-spinner>
 			<slot></slot>
-		`,
-	),
+		`
+	)
 );

--- a/src/style.css.ts
+++ b/src/style.css.ts
@@ -7,6 +7,16 @@ export default css`
 		display: none;
 	}
 
+	:host {
+		--cz-scrollbar-width: calc(var(--cz-spacing) * 2);
+		--cz-padding-block: ${sp(4)};
+		--cz-padding-inline: ${sp(4)};
+		@media screen and (min-width: 640px) {
+			--cz-padding-block: ${sp(10)};
+			--cz-padding-inline: ${sp(10)};
+		}
+	}
+
 	dialog {
 		position: relative;
 		margin: auto;
@@ -31,7 +41,8 @@ export default css`
 		display: flex;
 		align-items: center;
 		gap: ${sp(4)};
-		padding: ${sp(6)} ${sp(6)};
+		padding: var(--cz-padding-block)
+			calc(var(--cz-padding-inline) + var(--cz-scrollbar-width));
 
 		& h2 {
 			color: var(--cz-color-text-primary);
@@ -62,11 +73,17 @@ export default css`
 		overflow: hidden;
 		display: flex;
 		flex-direction: column;
-		padding: ${sp(6)};
 		color: var(--cz-color-text-primary);
 		font-size: var(--cz-text-base);
 		font-weight: var(--cz-font-weight-regular);
 		line-height: var(--cz-text-base-line-height);
+	}
+
+	.body {
+		overflow-y: auto;
+		scrollbar-gutter: stable both-edges;
+		padding: var(--cz-padding-block);
+		flex: 1;
 	}
 
 	.icon {
@@ -91,5 +108,26 @@ export default css`
 		position: absolute;
 		top: ${sp(4)};
 		right: ${sp(4)};
+	}
+
+	/* Width of the entire scroll bar */
+	::-webkit-scrollbar {
+		width: var(--cz-scrollbar-width);
+	}
+
+	/* Background/track of the scroll bar */
+	::-webkit-scrollbar-track {
+		background: var(--cz-color-gray-300);
+	}
+
+	/* The draggable scroll handle/thumb */
+	::-webkit-scrollbar-thumb {
+		background: var(--cz-color-gray-500);
+		border-radius: var(--cz-radius-2xl);
+	}
+
+	/* The handle on hover */
+	::-webkit-scrollbar-thumb:hover {
+		background: var(--cz-color-gray-400);
 	}
 `;

--- a/src/test/dialog.test.ts
+++ b/src/test/dialog.test.ts
@@ -25,7 +25,9 @@ describe('dialog', () => {
           </div>
           <div class="divider"></div>
           <div class="content" part="content">
-            <p>Test dialog content</p>
+            <div class="body">
+              <p>Test dialog content</p>
+            </div>
           </div>
         </dialog>
       </cosmoz-dialog-connectable>
@@ -50,7 +52,9 @@ describe('dialog', () => {
           </div>
           <div class="divider"></div>
           <div class="content" part="content">
-            <p>Test dialog content</p>
+            <div class="body">
+              <p>Test dialog content</p>
+            </div>
           </div>
         </dialog>
       </cosmoz-dialog-connectable>

--- a/src/test/loading.test.ts
+++ b/src/test/loading.test.ts
@@ -20,8 +20,10 @@ describe('cosmoz-dialog-loading', () => {
 					</div>
 					<div class="divider"></div>
 					<div class="content" part="content">
-						<cosmoz-spinner></cosmoz-spinner>
-						<slot></slot>
+						<div class="body">
+							<cosmoz-spinner></cosmoz-spinner>
+							<slot></slot>
+						</div>
 					</div>
 				</dialog>
 			</cosmoz-dialog-connectable>
@@ -48,8 +50,10 @@ describe('cosmoz-dialog-loading', () => {
 					</div>
 					<div class="divider"></div>
 					<div class="content" part="content">
-						<cosmoz-spinner></cosmoz-spinner>
-						<slot></slot>
+						<div class="body">
+							<cosmoz-spinner></cosmoz-spinner>
+							<slot></slot>
+						</div>
 					</div>
 				</dialog>
 			</cosmoz-dialog-connectable>
@@ -79,8 +83,10 @@ describe('cosmoz-dialog-loading', () => {
 					</div>
 					<div class="divider"></div>
 					<div class="content" part="content">
-						<cosmoz-spinner></cosmoz-spinner>
-						<slot></slot>
+						<div class="body">
+							<cosmoz-spinner></cosmoz-spinner>
+							<slot></slot>
+						</div>
 					</div>
 				</dialog>
 			</cosmoz-dialog-connectable>
@@ -105,8 +111,10 @@ describe('cosmoz-dialog-loading', () => {
 					</div>
 					<div class="divider"></div>
 					<div class="content" part="content">
-						<cosmoz-spinner></cosmoz-spinner>
-						<slot></slot>
+						<div class="body">
+							<cosmoz-spinner></cosmoz-spinner>
+							<slot></slot>
+						</div>
 					</div>
 				</dialog>
 			</cosmoz-dialog-connectable>
@@ -134,8 +142,10 @@ describe('cosmoz-dialog-loading', () => {
 					</div>
 					<div class="divider"></div>
 					<div class="content" part="content">
-						<cosmoz-spinner></cosmoz-spinner>
-						<slot></slot>
+						<div class="body">
+							<cosmoz-spinner></cosmoz-spinner>
+							<slot></slot>
+						</div>
 					</div>
 				</dialog>
 			</cosmoz-dialog-connectable>
@@ -175,8 +185,10 @@ describe('cosmoz-dialog-loading', () => {
 					</div>
 					<div class="divider"></div>
 					<div class="content" part="content">
-						<cosmoz-spinner></cosmoz-spinner>
-						<slot></slot>
+						<div class="body">
+							<cosmoz-spinner></cosmoz-spinner>
+							<slot></slot>
+						</div>
 					</div>
 				</dialog>
 			</cosmoz-dialog-connectable>


### PR DESCRIPTION
## Problem

The dialog's `.content` div had padding directly applied, which caused two issues:

1. **Scrollbar inset** — When content overflowed, the scrollbar appeared inside the padded area, creating an awkward visual inset where the scrollbar track sat within the padding, reducing the usable scroll area
2. **Consumers had to add their own padding** — Every time you used a form, list, or any content inside the dialog, you had to manually set padding on your content elements

## Solution

- **Moved padding from `.content` to a new inner `.body` div** — The scrollbar now sits flush at the edge of `.content`, while the padded area scrolls naturally with the content
- **No more manual padding** — Since `.body` provides padding, consumers no longer need to set padding on their own content (forms, inputs, lists, etc.). Just drop content in and it's properly spaced
- **Added responsive CSS custom properties** — `--cz-padding-block`, `--cz-padding-inline`, and `--cz-scrollbar-width` on `:host`, with a 640px breakpoint that increases padding from `4×` to `10×` spacing
- **Title padding accounts for scrollbar** — Right padding on `.title` includes `--cz-scrollbar-width` so title text aligns with content even when a scrollbar is visible
- **Custom scrollbar styling** — Webkit scrollbars styled with cosmoz-tokens colors and rounded thumbs
- **Loading dialog** — Replaced `padding` + `margin-right` with `gap` since padding is now on `.body`

## Before (consumer had to add padding)

```html
<cosmoz-dialog heading="Edit User" closeable>
  <div style="padding: 24px;">
    <form>...</form>
  </div>
</cosmoz-dialog>
```

## After (padding is built-in)

```html
<cosmoz-dialog heading="Edit User" closeable>
  <form>...</form>
</cosmoz-dialog>
```
