### PR TITLE
chore: bump playwright to 1.60.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@neovici/cosmoz-dialog",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@neovici/cosmoz-dialog",
-      "version": "5.0.1",
+      "version": "5.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@neovici/cosmoz-icons": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "typescript": "^5.4.3"
   },
   "overrides": {
-    "conventional-changelog-conventionalcommits": ">= 8.0.0"
+    "conventional-changelog-conventionalcommits": ">= 8.0.0",
+    "playwright": "1.60.0"
   }
 }


### PR DESCRIPTION
Pin resolved playwright version to 1.60.0 via npm overrides to avoid browser version mismatches.

Relates to FE-879